### PR TITLE
Add preprocessing strategy registry

### DIFF
--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,12 +1,14 @@
 """Ingestion pipeline modules."""
 
 from .preprocess import preprocess_files
+from .preprocessing import apply_preprocessing
 from .chunk import chunk_text
 from .embed import embed_chunks
 from .index import index_embeddings
 
 __all__ = [
     "preprocess_files",
+    "apply_preprocessing",
     "chunk_text",
     "embed_chunks",
     "index_embeddings",

--- a/ingest/preprocessing.py
+++ b/ingest/preprocessing.py
@@ -1,0 +1,78 @@
+"""Text preprocessing strategies for ingestion."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Dict
+
+
+# Registry mapping strategy names to callables
+_PREPROCESSORS: Dict[str, Callable[[str], str]] = {}
+
+
+def register(name: str) -> Callable[[Callable[[str], str]], Callable[[str], str]]:
+    """Decorator to register a preprocessing strategy."""
+
+    def decorator(func: Callable[[str], str]) -> Callable[[str], str]:
+        _PREPROCESSORS[name] = func
+        return func
+
+    return decorator
+
+
+@register("basic")
+def basic_preprocess(text: str) -> str:
+    """Basic cleaning: remove table of contents, strip lines and collapse blanks."""
+
+    lines = []
+    skip = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        lower = stripped.lower()
+        if not skip and "table of contents" in lower:
+            skip = True
+            continue
+        if skip:
+            if stripped == "":
+                skip = False
+            continue
+        lines.append(stripped)
+
+    cleaned = "\n".join(lines)
+    cleaned = re.sub(r"\n{2,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+@register("enrich")
+def enrich_preprocess(text: str) -> str:
+    """Basic cleaning with heading hierarchy appended."""
+    cleaned = basic_preprocess(text)
+
+    # extract headings hierarchy
+    headings = []
+    for line in cleaned.splitlines():
+        match = re.match(r"(#+)\s+(.*)", line)
+        if match:
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            headings.append((level, title))
+
+    if headings:
+        hierarchy_lines = ["\n", "Headings:"]
+        for level, title in headings:
+            prefix = "  " * (level - 1) + "- "
+            hierarchy_lines.append(f"{prefix}{title}")
+        cleaned += "\n" + "\n".join(hierarchy_lines)
+
+    return cleaned
+
+
+def apply_preprocessing(strategy: str, text: str) -> str:
+    """Apply the selected preprocessing strategy to text."""
+    if strategy not in _PREPROCESSORS:
+        available = ", ".join(sorted(_PREPROCESSORS))
+        raise ValueError(f"Unknown preprocessing strategy '{strategy}'. Available: {available}")
+    return _PREPROCESSORS[strategy](text)
+
+
+__all__ = ["apply_preprocessing"]

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from ingest.preprocessing import apply_preprocessing
+
+SAMPLE_MD = """# Title
+
+## Table of Contents
+- [Intro](#intro)
+- [Usage](#usage)
+
+# Intro
+
+Some text.
+
+# Usage
+More text.
+"""
+
+def test_basic_strategy() -> None:
+    cleaned = apply_preprocessing("basic", SAMPLE_MD)
+    assert "Table of Contents" not in cleaned
+    assert "- [Intro]" not in cleaned
+    assert cleaned.startswith("# Title")
+
+
+def test_enrich_strategy() -> None:
+    enriched = apply_preprocessing("enrich", SAMPLE_MD)
+    assert "Headings:" in enriched
+    assert "- Intro" in enriched
+    assert enriched.count("# Intro") == 1
+
+
+def test_unknown_strategy() -> None:
+    try:
+        apply_preprocessing("unknown", SAMPLE_MD)
+    except ValueError as e:
+        assert "Unknown preprocessing strategy" in str(e)
+    else:
+        assert False, "Expected ValueError"


### PR DESCRIPTION
## Summary
- introduce `ingest/preprocessing.py` with registry pattern
- provide `basic` and `enrich` preprocessing strategies
- expose `apply_preprocessing` via `ingest.__init__`
- add unit tests for preprocessing strategies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ed7eef8588333945a119c46622eed